### PR TITLE
Get rid of the doing it wrong _loading_text_domain message

### DIFF
--- a/mosparo-integration.php
+++ b/mosparo-integration.php
@@ -40,7 +40,7 @@ function mosparoIntegrationInitialize()
     $adminHelper = AdminHelper::getInstance();
     $adminHelper->initializeAdmin(__DIR__, plugin_dir_url(__FILE__), plugin_basename(__FILE__));
 }
-add_action('plugins_loaded', 'mosparoIntegrationInitialize', 1);
+add_action('init', 'mosparoIntegrationInitialize', 1);
 
 function mosparoIntegrationInitializeLate()
 {


### PR DESCRIPTION
call mosparoIntegrationInitialize on the init hook insteal of plugins_loaded.

As far is I can see, there should be no impact. 