### PR TITLE
Add Options "Version" to prevent __doing_it_wrong

### DIFF
--- a/src/MosparoIntegration/Module/ContactForm7/MosparoField.php
+++ b/src/MosparoIntegration/Module/ContactForm7/MosparoField.php
@@ -45,7 +45,7 @@ class MosparoField
 
     public function addFormTagGenerator()
     {
-        wpcf7_add_tag_generator('mosparo', 'mosparo', '', [$this, 'getTagGeneratorContent'], ['nameless' => 1]);
+        wpcf7_add_tag_generator('mosparo', 'mosparo', '', [$this, 'getTagGeneratorContent'], ['nameless' => 1, 'version' => 2]);
     }
 
     public function displayFormField()


### PR DESCRIPTION
Without the set version 2, in the backend we have a doing it wrong message. I can't see any sideeffects and the sent test form works.